### PR TITLE
ErrorSpecIssue parameters

### DIFF
--- a/src/ErrorSpecIssue.php
+++ b/src/ErrorSpecIssue.php
@@ -51,8 +51,20 @@ class ErrorSpecIssue
     /**
      * @return string
      */
-    public function getIssue()
+    public function getIssue(array $parameters = [])
     {
+        // If parameters have been provided, then ensure that each of the keys are wrapped
+        // with curly braces, and prepare it before passing it through strtr()
+        if (!empty($parameters))
+        {
+            $parsed = [];
+
+            foreach ($parameters as $key => $value)
+                $parsed['{' . $key . '}'] = $value;
+
+            return strtr($this->issue, $parsed);
+        }
+
         return $this->issue;
     }
 }

--- a/src/ErrorSpecIssue.php
+++ b/src/ErrorSpecIssue.php
@@ -55,12 +55,12 @@ class ErrorSpecIssue
     {
         // If parameters have been provided, then ensure that each of the keys are wrapped
         // with curly braces, and prepare it before passing it through strtr()
-        if (!empty($parameters))
-        {
+        if (!empty($parameters)) {
             $parsed = [];
 
-            foreach ($parameters as $key => $value)
+            foreach ($parameters as $key => $value) {
                 $parsed['{' . $key . '}'] = $value;
+            }
 
             return strtr($this->issue, $parsed);
         }


### PR DESCRIPTION
Adds an optional `array $parameters = []` parameter to the `ErrorSpecIssue::getIssue` method, that translates key/value pairs and automagically wraps the keys with curly braces before attempting to do string replacement in the `ErrorSpecIssue` item.

## Example

### ErrorCatalog
```
$error_catalog = new ErrorCatalog('products');
$validation_error = (new ErrorCatalogItem('VALIDATION_ERROR','Invalid request - see details', [400]))
			->addIssue(new ErrorSpecIssue('PayInCountryCodeMismatch', '', 'The specified code ({input-code}) does not match that of the product ({product-code})'))
```

### getIssue()
```
/** @var ErrorSpecIssue $issue */
$issue = $error_catalog->getIssueById('PayInCountryCodeMismatch')[0];

return $this->validationErrorResponse($response, $this->formatter->buildError(
    $error_catalog->getName(),
    $error_catalog->getMessage(),
    [
        'field' => '/payInCountryCode',
        'issue' => $issue->getIssue([ 'input-code' => 'FOO', 'product-code' => 'BAR' ])
    ]
));
```