### PR TITLE
Update parameter methods

### DIFF
--- a/src/ErrorSpecIssue.php
+++ b/src/ErrorSpecIssue.php
@@ -19,6 +19,9 @@ class ErrorSpecIssue
      */
     protected $issue;
 
+    /** @var array an array of parameters to be replaced in the issue message */
+    protected $parameters;
+
     /**
      * ErrorSpecIssue constructor.
      * @param string $id
@@ -49,10 +52,29 @@ class ErrorSpecIssue
     }
 
     /**
+     * @return $this
+     */
+    public function setParameters($parameters)
+    {
+        $this->parameters = $parameters;
+        
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    private function getParameters($parameters)
+    {
+        return $this->parameters;
+    }
+
+    /**
      * @return string
      */
-    public function getIssue(array $parameters = [])
+    public function getIssue()
     {
+        $parameters = $this->getParameters();
         // If parameters have been provided, then ensure that each of the keys are wrapped
         // with curly braces, and prepare it before passing it through strtr()
         if (!empty($parameters)) {


### PR DESCRIPTION
This is useful because sometimes you want to pass the object around before calling get issue on it an actual example case below:
```
if ($otpType->loaded())
{
	$error_catalog_item = $this->error_catalog->getItem('VALIDATION_ERROR');
	$error_spec_item = $error_catalog_item->getIssueById(CustomersErrorCatalogFactory::SCOPE_INVALID)[0];
	$error_spec_item->setParameters(['milk', 'cookies']);
	throw New ApiException($error_catalog_item, $error_spec_item, 'scope', $otpScope, $location = 'body', 400);
}
```