### PR TITLE
Updated typehints & visibility of properties

### DIFF
--- a/src/ErrorCatalog.php
+++ b/src/ErrorCatalog.php
@@ -7,17 +7,17 @@ class ErrorCatalog
     /**
      * @var string
      */
-    protected $namespace;
+    private $namespace;
 
     /**
      * @var string
      */
-    protected $language;
+    private $language;
 
     /**
      * @var array|ErrorCatalogItem[]
      */
-    protected $catalog = [];
+    private $catalog = [];
 
     /**
      * ErrorCatalog constructor.
@@ -26,6 +26,7 @@ class ErrorCatalog
      */
     public function __construct($namespace, $language = 'en-US')
     {
+    	// ? not used anywhere?
         $this->namespace = $namespace;
         $this->language = $language;
     }

--- a/src/ErrorCatalogItem.php
+++ b/src/ErrorCatalogItem.php
@@ -4,13 +4,17 @@ namespace PandaLeague\ErrorCatalog;
 
 class ErrorCatalogItem
 {
-    protected $name;
-    protected $message;
-    protected $httpStatusCodes;
+    private $name;
+    private $message;
+    private $httpStatusCodes;
 
-    protected $logLevel;
-    protected $suggestedApplicationActions = [];
-    protected $suggestedUserActions = [];
+    private $logLevel;
+    private $suggestedApplicationActions = [];
+    private $suggestedUserActions = [];
+
+    /**
+     * @var ErrorSpecIssue[]
+     */
     protected $issues = [];
 
     public function __construct($name, $message, array $httpStatusCodes)
@@ -59,6 +63,10 @@ class ErrorCatalogItem
         return $this->httpStatusCodes;
     }
 
+    /**
+     * @param $id
+     * @return ErrorSpecIssue[]
+     */
     public function getIssueById($id)
     {
         $return = [];
@@ -71,6 +79,10 @@ class ErrorCatalogItem
         return $return;
     }
 
+    /**
+     * @param $reference
+     * @return ErrorSpecIssue[]
+     */
     public function getIssueByReference($reference)
     {
         $return = [];

--- a/src/ErrorSpecIssue.php
+++ b/src/ErrorSpecIssue.php
@@ -7,20 +7,20 @@ class ErrorSpecIssue
     /**
      * @var string $id The ID for the issue.
      */
-    protected $id;
+    private $id;
 
     /**
      * @var string A reference to identify the issue by. Can be used to retrieve the issue but normally not shown in the catalog
      */
-    protected $reference;
+    private $reference;
 
     /**
      * @var string $issue Use String Formatter syntax to format the issue as a parameterized string. Localize the string.
      */
-    protected $issue;
+    private $issue;
 
     /** @var array an array of parameters to be replaced in the issue message */
-    protected $parameters;
+    private $parameters;
 
     /**
      * ErrorSpecIssue constructor.


### PR DESCRIPTION
`ErrorCatalogItem::getIssueById()` and `ErrorCatalogItem::getIssueByReference()` for some reason always return an array containing a single object, and on top of that the response isn't type-hinted, so the IDE's have no clue what `$issue` is:

`$issue = $error_catalog_item->getIssueById(CustomersErrorCatalogFactory::SCOPE_INVALID)[0];`

Also, class properties have no reason to be `protected`.